### PR TITLE
feat: external MG, default empty archetype

### DIFF
--- a/alzlib.go
+++ b/alzlib.go
@@ -116,12 +116,6 @@ func (az *AlzLib) Init(ctx context.Context, libs ...fs.FS) error {
 			return fmt.Errorf("error processing library %v: %w", lib, err)
 		}
 
-		// Only support definitions  (role, policy, policy set) in the first library
-		if i != 0 {
-			res.PolicyAssignments = make(map[string]*armpolicy.Assignment, 0)
-			res.LibArchetypes = make(map[string]*processor.LibArchetype, 0)
-		}
-
 		// Put results into the AlzLib
 		if err := az.addProcessedResult(res); err != nil {
 			return err
@@ -304,6 +298,18 @@ func (az *AlzLib) addProcessedResult(res *processor.Result) error {
 // generateArchetypes generates the archetypes from the result of the processor.
 // The archetypes are stored in the AlzLib instance.
 func (az *AlzLib) generateArchetypes(res *processor.Result) error {
+	// add empty archetype if it doesn't exist
+	if _, exists := res.LibArchetypes["empty"]; !exists {
+		res.LibArchetypes["empty"] = &processor.LibArchetype{
+			Name:                 "empty",
+			PolicyAssignments:    make([]string, 0),
+			PolicyDefinitions:    make([]string, 0),
+			PolicySetDefinitions: make([]string, 0),
+			RoleDefinitions:      make([]string, 0),
+		}
+	}
+
+	// generate alzlib archetypes
 	for k, v := range res.LibArchetypes {
 		if _, exists := az.Archetypes[k]; exists {
 			return fmt.Errorf("archetype %s already exists in the library", v.Name)

--- a/alzlib_test.go
+++ b/alzlib_test.go
@@ -27,7 +27,7 @@ func ExampleAlzLib_Init() {
 	}
 	fmt.Printf("Archetype count: %d\n", len(az.Archetypes))
 	// Output:
-	// Archetype count: 1
+	// Archetype count: 2
 }
 
 // Test_NewAlzLib_noDir tests the creation of a new AlzLib when supplied with a path

--- a/alzmanagementgroup_test.go
+++ b/alzmanagementgroup_test.go
@@ -25,7 +25,7 @@ func TestE2E(t *testing.T) {
 		DefaultLogAnalyticsWorkspaceId: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.OperationalInsights/workspaces/testlaworkspaceid",
 	}
 	arch := az.Archetypes["root"].WithWellKnownPolicyValues(vals)
-	assert.NoError(t, az.Deployment.AddManagementGroup("root", "root", "", arch))
+	assert.NoError(t, az.Deployment.AddManagementGroup("root", "root", "external", true, arch))
 	err = az.Deployment.MGs["root"].GeneratePolicyAssignmentAdditionalRoleAssignments(az)
 	assert.NoError(t, err)
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -31,7 +31,7 @@ func TestWellKnownParameterReplacement(t *testing.T) {
 	}
 
 	arch := az.Archetypes["test"].WithWellKnownPolicyValues(vals)
-	assert.NoError(t, az.Deployment.AddManagementGroup("test", "test", "", arch))
+	assert.NoError(t, az.Deployment.AddManagementGroup("test", "test", "external", true, arch))
 
 	paramValue := az.Deployment.MGs["test"].PolicyAssignments["Deploy-AzActivity-Log"].Properties.Parameters["logAnalytics"].Value
 	assert.Equal(t, "testlaworkspaceid", paramValue)
@@ -449,7 +449,7 @@ func TestAddManagementGroup(t *testing.T) {
 	arch = arch.WithWellKnownPolicyValues(wkvs)
 
 	// test adding a new management group with no parent
-	err := d.AddManagementGroup("mg1", "mg1", "", arch)
+	err := d.AddManagementGroup("mg1", "mg1", "external", true, arch)
 	assert.NoError(t, err)
 	assert.Len(t, d.MGs, 1)
 	assert.Contains(t, d.MGs, "mg1")
@@ -459,7 +459,7 @@ func TestAddManagementGroup(t *testing.T) {
 	assert.Empty(t, d.MGs["mg1"].children)
 
 	// test adding a new management group with a parent
-	err = d.AddManagementGroup("mg2", "mg2", "mg1", arch)
+	err = d.AddManagementGroup("mg2", "mg2", "mg1", false, arch)
 	assert.NoError(t, err)
 	assert.Len(t, d.MGs, 2)
 	assert.Contains(t, d.MGs, "mg2")
@@ -471,7 +471,7 @@ func TestAddManagementGroup(t *testing.T) {
 	assert.Equal(t, "mg2", d.MGs["mg1"].children[0].Name)
 
 	// test adding a new management group with a non-existent parent
-	err = d.AddManagementGroup("mg3", "mg3", "mg4", arch)
+	err = d.AddManagementGroup("mg3", "mg3", "mg4", false, arch)
 	assert.Error(t, err)
 	assert.Len(t, d.MGs, 2)
 	assert.Contains(t, d.MGs, "mg1")
@@ -479,7 +479,7 @@ func TestAddManagementGroup(t *testing.T) {
 	assert.NotContains(t, d.MGs, "mg3")
 
 	// test adding a new management group with multiple root management groups
-	err = d.AddManagementGroup("mg4", "mg4", "", arch)
+	err = d.AddManagementGroup("mg4", "mg4", "external", true, arch)
 	assert.Error(t, err)
 	assert.Len(t, d.MGs, 2)
 	assert.Contains(t, d.MGs, "mg1")
@@ -487,7 +487,7 @@ func TestAddManagementGroup(t *testing.T) {
 	assert.NotContains(t, d.MGs, "mg4")
 
 	// test adding a new management group with an existing name
-	err = d.AddManagementGroup("mg1", "mg1", "", arch)
+	err = d.AddManagementGroup("mg1", "mg1", "external", true, arch)
 	assert.Error(t, err)
 	assert.Len(t, d.MGs, 2)
 	assert.Contains(t, d.MGs, "mg1")

--- a/lib/archetype_definitions/archetype_definition_empty.json
+++ b/lib/archetype_definitions/archetype_definition_empty.json
@@ -1,7 +1,0 @@
-{
-  "name": "empty",
-  "policy_assignments": [],
-  "policy_definitions": [],
-  "policy_set_definitions": [],
-  "role_definitions": []
-}

--- a/wellknownparametervalues.go
+++ b/wellknownparametervalues.go
@@ -2,13 +2,13 @@ package alzlib
 
 import "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy"
 
-// PolicyAssignmentsParameterValues represents the values for well-known policy assignment parameters.
+// policyAssignmentsParameterValues represents the values for well-known policy assignment parameters.
 // The first map key is the assignment name, the second is the parameter name, and the value is the parameter value
-type PolicyAssignmentsParameterValues map[string]map[string]*armpolicy.ParameterValuesValue
+type policyAssignmentsParameterValues map[string]map[string]*armpolicy.ParameterValuesValue
 
 // getWellKnownPolicyAssignmentParameterValues is used by the *Archetype.WithWellKnownPolicyValues() method to set the values for well-known policy assignment parameters.
-func getWellKnownPolicyAssignmentParameterValues(opts *WellKnownPolicyValues) PolicyAssignmentsParameterValues {
-	return PolicyAssignmentsParameterValues{
+func getWellKnownPolicyAssignmentParameterValues(opts *WellKnownPolicyValues) policyAssignmentsParameterValues {
+	return policyAssignmentsParameterValues{
 		"Deploy-AzActivity-Log": {
 			"logAnalytics": {
 				Value: opts.DefaultLogAnalyticsWorkspaceId,


### PR DESCRIPTION
* Will now create a `empty` archetype by default
* Support external parent
* Init - No longer prevent archetypes being created from fs.FS with index != 0